### PR TITLE
Fixing display, and updating deprecated function.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === WooCommerce Availability Chart ===
-Contributors: sormano, growdev
+Contributors: shopplugins, sormano, growdev
 Donate link: http://www.jeroensormani.com/donate/
 Tags: woocommerce, woocommerce stock, stock, woocommerce availability, woocommerce chart, woocommerce availability chart
 Requires at least: 3.6

--- a/woocommerce-availability-chart.php
+++ b/woocommerce-availability-chart.php
@@ -97,7 +97,7 @@ class WooCommerce_Availability_Chart {
 			foreach ( $available_variations as $variation ) :
 
 				$max_stock = $product->get_total_stock();
-				$var = get_product( $variation['variation_id'] );
+				$var = wc_get_product( $variation['variation_id'] );
 
 				if ( true == $var->variation_has_stock ) :
 
@@ -166,8 +166,9 @@ class WooCommerce_Availability_Chart {
 				$term = get_term_by( 'slug', $value, str_replace( 'attribute_', '', $attr ) );
 				if ( isset( $term->name ) ) :
 					$variation_name .= $term->name . ', ';
+
 				endif;
-				
+
 			else :
 
 				$variation_name .= $value;

--- a/woocommerce-availability-chart.php
+++ b/woocommerce-availability-chart.php
@@ -1,7 +1,7 @@
 <?PHP
 /*
 Plugin Name: WooCommerce Availability Chart
-Plugin URI: https://github.com/growdev/woocommerce-availability-chart/
+Plugin URI: https://github.com/growdevelopment/woocommerce-availability-chart/
 Description: WooCommerce Availability Chart displays a nice looking chart on variation product pages with the availability of products
 Version: 1.0.0
 Author: Shop Plugins, Jeroen Sormani, Daniel Espinoza

--- a/woocommerce-availability-chart.php
+++ b/woocommerce-availability-chart.php
@@ -4,11 +4,11 @@ Plugin Name: WooCommerce Availability Chart
 Plugin URI: https://github.com/growdev/woocommerce-availability-chart/
 Description: WooCommerce Availability Chart displays a nice looking chart on variation product pages with the availability of products
 Version: 1.0.0
-Author: Grow Development / Jeroen Sormani
-Author URI: http://growdevelopment.com
+Author: Shop Plugins, Jeroen Sormani, Daniel Espinoza
+Author URI: http://shopplugins.com
 Text Domain: woocommerce-availability-chart
 
- * Copyright Grow Development
+ * Copyright Shop Plugins
  *
  *     This file is part of WooCommerce Availability Chart,
  *     a plugin for WordPress.
@@ -90,7 +90,7 @@ class WooCommerce_Availability_Chart {
 		$available_variations = $product->get_available_variations();
 
 		?>
-		<h3 class='avilability-chart-title'><?php _e( 'Availability', 'woocommerce-availability-chart' ); ?></h3>
+		<h3 class='availability-chart-title'><?php _e( 'Availability', 'woocommerce-availability-chart' ); ?></h3>
 		<div class='availability-chart'><?php
 
 			// Loop variations
@@ -171,7 +171,7 @@ class WooCommerce_Availability_Chart {
 
 			else :
 
-				$variation_name .= $value;
+				$variation_name .= $value . ', ';
 
 			endif;
 

--- a/woocommerce-availability-chart.php
+++ b/woocommerce-availability-chart.php
@@ -161,7 +161,7 @@ class WooCommerce_Availability_Chart {
 
 		foreach ( $attributes as $attr => $value ) :
 
-			if ( term_exists( $value ) ) :
+			if ( term_exists( $value, str_replace( 'attribute_', '', $attr ) ) ) :
 
 				$term = get_term_by( 'slug', $value, str_replace( 'attribute_', '', $attr ) );
 				if ( isset( $term->name ) ) :


### PR DESCRIPTION
Changed `get_product()` to `wc_get_product()`.  We should add a compatibility class later, or specify that the plugin requires 2.2.x.

When testing I noticed that the display for four variations weren't showing correctly:
![ship your idea wc22 test](https://cloud.githubusercontent.com/assets/290886/5607016/8ddd479c-940e-11e4-9ef9-0030d0369a8e.jpg)

They should look like this: 
![ship your idea wc22 test-1](https://cloud.githubusercontent.com/assets/290886/5607017/93979700-940e-11e4-8c85-7d6e14dc5f5a.jpg)

Turns out `blue` and `black` exist as terms, but don't have terms in the taxonomy. So I added the same taxonomy string to the `term_exists()` call. 